### PR TITLE
Allow all formats of dired listings

### DIFF
--- a/dired-recent.el
+++ b/dired-recent.el
@@ -149,10 +149,10 @@ Remove the last elements as appropriate according to
                            label)
                           label))
                        (t path))))
-	    (setq dired-recent-directories
+        (setq dired-recent-directories
               (let ((new-list (cons new
                                     (delete new dired-recent-directories))))
-		        (if dired-recent-max-directories
+                (if dired-recent-max-directories
                     (seq-take new-list dired-recent-max-directories)
                   new-list)))))))
 

--- a/dired-recent.el
+++ b/dired-recent.el
@@ -65,6 +65,9 @@ nil means to remember all."
           (const :tag "All" nil)
           (integer)))
 
+(defvar find-program)
+(defvar find-args)
+
 ;;;###autoload
 (defun dired-recent-open ()
   "Show the dired history.  See: `dired-recent-mode'."

--- a/dired-recent.el
+++ b/dired-recent.el
@@ -133,14 +133,16 @@ Remove the last elements as appropriate according to
                                 0 1 'dired-recent-restore-file-list
                                 (buffer-local-value
                                  'revert-buffer-function
-                                 buf) label))))
+                                 buf)
+                                (copy-sequence label)))))
                           label))
                        ((consp path)
                         (let ((label (file-name-nondirectory
                                       (car path))))
                           (put-text-property
                            0 1 'dired-recent-restore-file-list
-                           (cons label (cdr path))
+                           (cons (copy-sequence label)
+                                 (cdr path))
                            label)
                           label))
                        (t path))))

--- a/dired-recent.el
+++ b/dired-recent.el
@@ -68,7 +68,7 @@ nil means to remember all."
 (defcustom dired-recent-add-virtual-listings nil
   "Whether to add virtual listings to history.
 
-If this option is nil special dired buffers created by a
+If this option is nil special dired buffers created by
 processes (see `find-dired') or created by passing a list to
 `dired' are ignored."
   :type 'boolean)

--- a/dired-recent.el
+++ b/dired-recent.el
@@ -137,7 +137,7 @@ Remove the last elements as appropriate according to
                                 (buffer-local-value
                                  'revert-buffer-function
                                  buf)
-                                (copy-sequence label)))))
+                                label))))
                           label))
                        ((consp path)
                         (let ((label (file-name-nondirectory


### PR DESCRIPTION
Hi, thanks for this nice project! Dired also accepts custom file listings when a list is passed as argument, I added the ability to save those custom listings, too. You can test this by using something like:

    (dired
     '("*my-listing*" "~/.emacs.d" "~/.config"))

I also added storing history for dired buffers created by processes like `find-dired` or `find-grep-dired`. 