### PR TITLE
set print-level & print-level to nil to avoid truncation in prin1

### DIFF
--- a/dired-recent.el
+++ b/dired-recent.el
@@ -242,7 +242,9 @@ potentially slow."
   "Save the dired history to `dired-recent-directories-file'."
   (interactive)
   (with-temp-file dired-recent-directories-file
-    (prin1 dired-recent-directories (current-buffer))))
+    (let ((print-length nil)
+          (print-level nil))
+      (prin1 dired-recent-directories (current-buffer)))))
 
 ;;;###autoload
 (define-minor-mode dired-recent-mode


### PR DESCRIPTION
`prin1` is affected by the value of `print-level` and `print-length` (https://www.gnu.org/software/emacs/manual/html_node/elisp/Output-Variables.html).

if set low enough, they will silently corrupt `dired-recent-directories-file` (will end with bare "...").